### PR TITLE
탐색 탭 구현 및 게시물 수정 사항 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import NavBar from './components/NavBar.tsx';
 import { useUserContext } from './contexts/UserContext.tsx';
 import AddText from './pages/AddPost/AddText.tsx';
 import UploadPhoto from './pages/AddPost/UploadPhoto.tsx';
+import EditPost from './pages/EditPost/EditPost.tsx';
 import DetailExplore from './pages/Explore/DetailExplore.tsx';
 import Explore from './pages/Explore/Explore.tsx';
 import ExploreFeed from './pages/Explore/ExploreFeed.tsx';
@@ -112,6 +113,7 @@ const router = createBrowserRouter([
 				path: 'account/edit/gender/',
 				element: <Gender />,
 			},
+			{ path: 'post/edit/:id/', element: <EditPost /> },
 			{
 				path: '*',
 				element: <Navigate to="" />,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,9 @@ import NavBar from './components/NavBar.tsx';
 import { useUserContext } from './contexts/UserContext.tsx';
 import AddText from './pages/AddPost/AddText.tsx';
 import UploadPhoto from './pages/AddPost/UploadPhoto.tsx';
+import DetailExplore from './pages/Explore/DetailExplore.tsx';
 import Explore from './pages/Explore/Explore.tsx';
+import ExploreFeed from './pages/Explore/ExploreFeed.tsx';
 import Home from './pages/Home.tsx';
 import Login from './pages/Login/Login.tsx';
 import Certification from './pages/Login/passwordRecovery/Certification.tsx';
@@ -53,6 +55,14 @@ const router = createBrowserRouter([
 			{
 				path: 'explore/',
 				element: <Explore />,
+			},
+			{
+				path: 'explore/:category/',
+				element: <DetailExplore />,
+			},
+			{
+				path: 'explore/:category/:id',
+				element: <ExploreFeed />,
 			},
 			{
 				path: 'addPost/',

--- a/src/apis/explore.ts
+++ b/src/apis/explore.ts
@@ -40,8 +40,13 @@ export const KorCategoryMap: { [key in string]: CategoryType } = {
 	뉴스: 'NEWS',
 };
 
+type ExplorePreviewReponseType = {
+	postId: number;
+	thumbnailUrl: string;
+};
+
 type CategoryResponseType = {
-	previews: PreviewType[];
+	previews: ExplorePreviewReponseType[];
 	pageInfo: ExplorePreviewType['pageInfo'];
 };
 
@@ -64,7 +69,15 @@ export const getCategoryExplore = async (
 
 		const result = response.data;
 
-		return { previews: result.previews, pageInfo: result.pageInfo };
+		const formatedPreviews = result.previews.map((preview) => {
+			const formated: PreviewType = {
+				id: preview.postId,
+				thumbnailUrl: preview.thumbnailUrl,
+			};
+			return formated;
+		});
+
+		return { previews: formatedPreviews, pageInfo: result.pageInfo };
 	} catch (error) {
 		const err = error as AxiosError<APIErrorResponseType>;
 
@@ -96,7 +109,15 @@ export const getCompactExplore = async (
 
 		const result = response.data;
 
-		return result.previews;
+		const formatedPreviews = result.previews.map((preview) => {
+			const formated: PreviewType = {
+				id: preview.postId,
+				thumbnailUrl: preview.thumbnailUrl,
+			};
+			return formated;
+		});
+
+		return formatedPreviews;
 	} catch (error) {
 		const err = error as AxiosError<APIErrorResponseType>;
 

--- a/src/apis/explore.ts
+++ b/src/apis/explore.ts
@@ -5,11 +5,13 @@ import {
 	APIErrorResponseType,
 	CategoryType,
 	ExplorePreviewType,
+	PreviewType,
 } from '../types';
 
 // 카테고리 대소문자 mapping
 export const CategoryMap: { [key in string]: CategoryType } = {
 	game: 'GAME',
+	travel: 'TRAVEL',
 	food: 'FOOD',
 	sport: 'SPORT',
 	animal: 'ANIMAL',
@@ -19,6 +21,25 @@ export const CategoryMap: { [key in string]: CategoryType } = {
 	art: 'ART',
 	news: 'NEWS',
 };
+
+export const KorCategoryMap: { [key in string]: CategoryType } = {
+	게임: 'GAME',
+	여행: 'TRAVEL',
+	음식: 'FOOD',
+	스포츠: 'SPORT',
+	동물: 'ANIMAL',
+	일상: 'LIFE',
+	패션: 'FASHION',
+	유머: 'HUMOR',
+	예술: 'ART',
+	뉴스: 'NEWS',
+};
+
+type CategoryResponseType = {
+	postMediasBriefList: PreviewType[];
+	pageInfo: ExplorePreviewType['pageInfo'];
+};
+
 // 탐색탭 preview 가져오기
 export const getCategoryExplore = async (
 	category: CategoryType,
@@ -26,7 +47,7 @@ export const getCategoryExplore = async (
 	accessToken: string
 ): Promise<ExplorePreviewType | null> => {
 	try {
-		const response = await axios.get<ExplorePreviewType>(
+		const response = await axios.get<CategoryResponseType>(
 			`${baseURL}/api/v1/explore?page=${page}&category=${category}&sort=RANDOM`,
 			{
 				headers: {
@@ -38,7 +59,39 @@ export const getCategoryExplore = async (
 
 		const result = response.data;
 
-		return result;
+		return { previews: result.postMediasBriefList, pageInfo: result.pageInfo };
+	} catch (error) {
+		const err = error as AxiosError<APIErrorResponseType>;
+
+		if (err.response && err.response.data) {
+			alert(err.response.data.message);
+		} else {
+			alert('Error occurred');
+		}
+
+		return null;
+	}
+};
+
+// 탐색탭 미리보기 가져오기
+export const getCompactExplore = async (
+	category: CategoryType,
+	accessToken: string
+): Promise<PreviewType[] | null> => {
+	try {
+		const response = await axios.get<CategoryResponseType>(
+			`${baseURL}/api/v1/explore?size=6&category=${category}&sort=RANDOM`,
+			{
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+					'Content-Type': 'application/json',
+				},
+			}
+		);
+
+		const result = response.data;
+
+		return result.postMediasBriefList;
 	} catch (error) {
 		const err = error as AxiosError<APIErrorResponseType>;
 

--- a/src/apis/explore.ts
+++ b/src/apis/explore.ts
@@ -1,0 +1,53 @@
+import axios, { AxiosError } from 'axios';
+
+import { baseURL } from '../constants';
+import {
+	APIErrorResponseType,
+	CategoryType,
+	ExplorePreviewType,
+} from '../types';
+
+// 카테고리 대소문자 mapping
+export const CategoryMap: { [key in string]: CategoryType } = {
+	game: 'GAME',
+	food: 'FOOD',
+	sport: 'SPORT',
+	animal: 'ANIMAL',
+	life: 'LIFE',
+	fashion: 'FASHION',
+	humor: 'HUMOR',
+	art: 'ART',
+	news: 'NEWS',
+};
+// 탐색탭 preview 가져오기
+export const getCategoryExplore = async (
+	category: CategoryType,
+	page: number,
+	accessToken: string
+): Promise<ExplorePreviewType | null> => {
+	try {
+		const response = await axios.get<ExplorePreviewType>(
+			`${baseURL}/api/v1/explore?page=${page}&category=${category}&sort=RANDOM`,
+			{
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+					'Content-Type': 'application/json',
+				},
+			}
+		);
+
+		const result = response.data;
+
+		return result;
+	} catch (error) {
+		const err = error as AxiosError<APIErrorResponseType>;
+
+		if (err.response && err.response.data) {
+			alert(err.response.data.message);
+		} else {
+			alert('Error occurred');
+		}
+
+		return null;
+	}
+};

--- a/src/apis/explore.ts
+++ b/src/apis/explore.ts
@@ -112,11 +112,12 @@ export const getCompactExplore = async (
 
 export const getExploreFeed = async (
 	postId: number,
+	page: number,
 	accessToken: string
 ): Promise<FeedType | null> => {
 	try {
 		const response = await axios.get<FeedResponseType>(
-			`${baseURL}/api/v1/explore/${postId}`,
+			`${baseURL}/api/v1/explore/${postId}?page=${page}`,
 			{
 				headers: {
 					Authorization: `Bearer ${accessToken}`,

--- a/src/apis/explore.ts
+++ b/src/apis/explore.ts
@@ -98,7 +98,7 @@ export const getCompactExplore = async (
 ): Promise<PreviewType[] | null> => {
 	try {
 		const response = await axios.get<CategoryResponseType>(
-			`${baseURL}/api/v1/explore?size=6&category=${category}&size=6`,
+			`${baseURL}/api/v1/explore?size=6&category=${category}&page=0`,
 			{
 				headers: {
 					Authorization: `Bearer ${accessToken}`,

--- a/src/apis/explore.ts
+++ b/src/apis/explore.ts
@@ -36,7 +36,7 @@ export const KorCategoryMap: { [key in string]: CategoryType } = {
 };
 
 type CategoryResponseType = {
-	postMediasBriefList: PreviewType[];
+	previews: PreviewType[];
 	pageInfo: ExplorePreviewType['pageInfo'];
 };
 
@@ -59,7 +59,7 @@ export const getCategoryExplore = async (
 
 		const result = response.data;
 
-		return { previews: result.postMediasBriefList, pageInfo: result.pageInfo };
+		return { previews: result.previews, pageInfo: result.pageInfo };
 	} catch (error) {
 		const err = error as AxiosError<APIErrorResponseType>;
 
@@ -91,7 +91,7 @@ export const getCompactExplore = async (
 
 		const result = response.data;
 
-		return result.postMediasBriefList;
+		return result.previews;
 	} catch (error) {
 		const err = error as AxiosError<APIErrorResponseType>;
 

--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -79,7 +79,7 @@ export const tryPost = async ({
 		return response;
 	} catch (error) {
 		const err = error as AxiosError<APIErrorResponseType>;
-		console.log(err.response);
+
 		if (err.response && err.response.status == 401) {
 			try {
 				const newAccessToken = await resetAccessToken();

--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -42,7 +42,7 @@ type PostResponseType = {
 	category: CategoryType;
 };
 // 피드 response 형
-type FeedResponseType = {
+export type FeedResponseType = {
 	posts: PostResponseType[];
 	pageInfo: {
 		page: number;

--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -690,6 +690,56 @@ export const deletePost = async (
 	}
 };
 
+// 게시물 하나 정보 가져오기
+export const getPost = async (
+	postId: number,
+	accessToken: string
+): Promise<PostType | null> => {
+	try {
+		const response = await axios.get<PostResponseType>(
+			`${baseURL}/api/v1/posts/${postId}`,
+			{
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+				},
+			}
+		);
+		const result = response.data;
+
+		const user: MiniProfileType = {
+			userId: result.author.id,
+			profileImageUrl: result.author.profileImageUrl,
+			username: result.author.username,
+			name: '',
+		};
+
+		return {
+			id: result.id,
+			content: result.content,
+			media: result.media,
+			createdAt: result.createdAt,
+			likeCount: result.likeCount,
+			commentCount: result.commentCount,
+			user: user,
+			liked: result.liked,
+			saved: result.saved,
+			hideLike: result.hideLike,
+			category: result.category,
+		};
+	} catch (error) {
+		const err = error as AxiosError<APIErrorResponseType>;
+
+		if (err.response && err.response.data) {
+			alert(err.response.data.message);
+		} else {
+			alert('Error occurred');
+		}
+
+		return null;
+	}
+};
+
+// 게시물 수정
 export const editPost = async (
 	postId: number,
 	content: string,

--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosError } from 'axios';
+
 import { baseURL } from '../constants';
-import { resetAccessToken } from './login';
 import {
 	APIErrorResponseType,
 	CategoryType,
@@ -11,6 +11,8 @@ import {
 	MiniProfileType,
 	PostType,
 } from '../types.ts';
+
+import { resetAccessToken } from './login';
 
 type TryPostType = {
 	content: string;
@@ -648,6 +650,62 @@ export const deleteReply = async (
 				Authorization: `Bearer ${accessToken}`,
 			},
 		});
+
+		return { status: 'success' };
+	} catch (error) {
+		const err = error as AxiosError<APIErrorResponseType>;
+
+		if (err.response && err.response.data) {
+			alert(err.response.data.message);
+		} else {
+			alert('Error occurred');
+		}
+
+		return null;
+	}
+};
+
+export const deletePost = async (
+	postId: number,
+	accessToken: string
+): Promise<SuccessFailResponse | null> => {
+	try {
+		await axios.delete(`${baseURL}/api/v1/posts/${postId}}`, {
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+			},
+		});
+
+		return { status: 'success' };
+	} catch (error) {
+		const err = error as AxiosError<APIErrorResponseType>;
+
+		if (err.response && err.response.data) {
+			alert(err.response.data.message);
+		} else {
+			alert('Error occurred');
+		}
+
+		return null;
+	}
+};
+
+export const editPost = async (
+	postId: number,
+	content: string,
+	accessToken: string
+): Promise<SuccessFailResponse | null> => {
+	try {
+		await axios.put(
+			`${baseURL}/api/v1/posts/${postId}}`,
+			{ content: content },
+			{
+				headers: {
+					Authorization: `Bearer ${accessToken}`,
+					'Content-Type': 'appication/json',
+				},
+			}
+		);
 
 		return { status: 'success' };
 	} catch (error) {

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import {
@@ -51,6 +52,7 @@ const Profile = styled.div`
 	height: 2rem;
 	border-radius: 70%;
 	overflow: hidden;
+	cursor: pointer;
 	display: inline;
 	border: 1px solid ${getColor('grey')};
 	& > img {
@@ -76,6 +78,7 @@ const UsernameContentBox = styled.div`
 	}
 	& > .username {
 		font-weight: 600;
+		cursor: pointer;
 	}
 `;
 
@@ -116,6 +119,8 @@ export default function Comment({
 
 	const { accessToken, userId } = useUserContext();
 
+	const navigate = useNavigate();
+
 	useEffect(() => {
 		const fetchCommentData = async () => {
 			if (showReply && comment && replyReload) {
@@ -152,7 +157,11 @@ export default function Comment({
 
 	return (
 		<CommentContainer>
-			<Profile>
+			<Profile
+				onClick={() => {
+					navigate(`/${comment.user.username}`);
+				}}
+			>
 				<img
 					src={
 						comment.user.profileImageUrl !== ''
@@ -163,7 +172,14 @@ export default function Comment({
 				/>
 			</Profile>
 			<UsernameContentBox>
-				<span className="username">{comment.user.username}</span>
+				<span
+					className="username"
+					onClick={() => {
+						navigate(`/${comment.user.username}`);
+					}}
+				>
+					{comment.user.username}
+				</span>
 				<span>{comment.text}</span>
 				<div className="reaction-bar">
 					<TextBox
@@ -216,7 +232,12 @@ export default function Comment({
 					return (
 						<>
 							<ReplyContent>
-								<Profile className="reply">
+								<Profile
+									className="reply"
+									onClick={() => {
+										navigate(`/${comment.user.username}`);
+									}}
+								>
 									<img
 										src={
 											reply.user.profileImageUrl !== ''
@@ -227,7 +248,14 @@ export default function Comment({
 									/>
 								</Profile>
 								<UsernameContentBox>
-									<span className="username">{reply.user.username}</span>
+									<span
+										className="username"
+										onClick={() => {
+											navigate(`/${comment.user.username}`);
+										}}
+									>
+										{reply.user.username}
+									</span>
 									<span>{reply.text}</span>
 									<div className="reaction-bar">
 										<TextBox

--- a/src/components/Comment/Comment.tsx
+++ b/src/components/Comment/Comment.tsx
@@ -21,6 +21,7 @@ type CommentProps = {
 	handlePostReply: (comment: CommentType) => void;
 	handleDeleteComment: (comment: CommentType) => void;
 	setReload: (reload: boolean) => void;
+	postAuthorId: number;
 };
 
 const CommentContainer = styled.div`
@@ -111,6 +112,7 @@ export default function Comment({
 	handlePostReply,
 	handleDeleteComment,
 	setReload,
+	postAuthorId,
 }: CommentProps) {
 	const [replies, setReplies] = useState<CommentPageType>();
 	const [showReply, setShowReply] = useState(false);
@@ -188,7 +190,7 @@ export default function Comment({
 					>
 						답글 달기
 					</TextBox>
-					{comment.user.userId === userId && (
+					{(comment.user.userId === userId || postAuthorId === userId) && (
 						<TextBox
 							className="secondary-text"
 							onClick={() => {
@@ -275,7 +277,8 @@ export default function Comment({
 										>
 											답글 달기
 										</TextBox>
-										{reply.user.userId === userId && (
+										{(reply.user.userId === userId ||
+											postAuthorId === userId) && (
 											<TextBox
 												className="secondary-text"
 												onClick={() => {

--- a/src/components/Comment/CommentList.tsx
+++ b/src/components/Comment/CommentList.tsx
@@ -27,11 +27,13 @@ export default function CommentList({
 	handlePostReply,
 	handleDeleteComment,
 	setReload,
+	postAuthorId,
 }: {
 	comments: CommentType[];
 	handlePostReply: (comment: CommentType) => void;
 	handleDeleteComment: (comment: CommentType) => void;
 	setReload: (reload: boolean) => void;
+	postAuthorId: number;
 }) {
 	return (
 		<CommentListWrapper>
@@ -41,6 +43,7 @@ export default function CommentList({
 					handlePostReply={handlePostReply}
 					handleDeleteComment={handleDeleteComment}
 					setReload={setReload}
+					postAuthorId={postAuthorId}
 				/>
 			))}
 		</CommentListWrapper>

--- a/src/components/Comment/CommentList.tsx
+++ b/src/components/Comment/CommentList.tsx
@@ -8,6 +8,7 @@ const CommentListWrapper = styled.ul`
 	padding: 0;
 	margin: 0;
 	width: 100%;
+	height: 100%;
 	gap: 1rem;
 	display: flex;
 	flex-direction: column;

--- a/src/components/Comment/CommentModal.tsx
+++ b/src/components/Comment/CommentModal.tsx
@@ -109,6 +109,7 @@ export default function CommentModal({
 							handlePostReply={handlePostReply}
 							handleDeleteComment={handleDeleteComment}
 							setReload={setReload}
+							postAuthorId={post.user.userId}
 						/>
 					)}
 					<CommentInput

--- a/src/components/Comment/CommentModal.tsx
+++ b/src/components/Comment/CommentModal.tsx
@@ -24,7 +24,7 @@ const ModalContent = styled.div`
 	padding-bottom: 0.5rem;
 	background-color: ${getColor('grey')};
 	border-radius: 0.5rem 0.5rem 0 0;
-	max-height: 70%;
+	height: 70%;
 `;
 
 export default function CommentModal({

--- a/src/components/Explore/Preview.tsx
+++ b/src/components/Explore/Preview.tsx
@@ -1,8 +1,10 @@
+import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import posts from '../../test/data/postlist.json';
-import { PostListProps } from '../../types';
+import { getCompactExplore } from '../../apis/explore';
+import { useUserContext } from '../../contexts/UserContext';
+import { CategoryType, PreviewType } from '../../types';
 import KorToEng from '../CreatePost/KorToEng';
 import PostList from '../Post/PostList';
 
@@ -41,21 +43,53 @@ const RightArrow = styled.img`
 	margin-right: 0.2rem;
 	padding-top: 0.2rem;
 `;
-type PreviewType = {
+type PreviewProps = {
 	category: string;
 };
 
-export default function Preview({ category }: PreviewType) {
+export default function Preview({ category }: PreviewProps) {
 	const navigate = useNavigate();
-	const newPosts: PostListProps = posts;
+
+	const [newPosts, setNewPosts] = useState<PreviewType[]>([]);
+
+	const { accessToken } = useUserContext();
+
+	useEffect(() => {
+		const fetchExploreData = async () => {
+			try {
+				const fetchData = await getCompactExplore(
+					KorToEng(category) as CategoryType,
+					accessToken
+				);
+				if (!fetchData) {
+					return;
+				}
+
+				setNewPosts(fetchData);
+			} catch {
+				return;
+			}
+		};
+
+		fetchExploreData();
+	}, []);
+
 	return (
 		<>
 			<Header>
 				<Subject>{category}</Subject>
 				<Text>관련 게시물</Text>
 			</Header>
-			<PostList {...newPosts} />
-			<More onClick={() => navigate(`/explore/${KorToEng(category)}`)}>
+			<PostList
+				previews={newPosts}
+				callbackUrl={'/explore/' + KorToEng(category)?.toLowerCase()}
+				useHashtag={false}
+			/>
+			<More
+				onClick={() =>
+					navigate(`/explore/${KorToEng(category)?.toLowerCase()}`)
+				}
+			>
 				더보기
 				<RightArrow
 					src="https://cdn-icons-png.flaticon.com/512/271/271228.png"

--- a/src/components/Explore/Preview.tsx
+++ b/src/components/Explore/Preview.tsx
@@ -1,9 +1,10 @@
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import PostList from '../Post/PostList';
+
 import posts from '../../test/data/postlist.json';
 import { PostListProps } from '../../types';
-import { useNavigate } from 'react-router-dom';
 import KorToEng from '../CreatePost/KorToEng';
+import PostList from '../Post/PostList';
 
 const Header = styled.div`
 	width: 100%;

--- a/src/components/Explore/SubjectBar.tsx
+++ b/src/components/Explore/SubjectBar.tsx
@@ -1,6 +1,7 @@
-import styled from 'styled-components';
-import KorToEng from '../CreatePost/KorToEng';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+import KorToEng from '../CreatePost/KorToEng';
 
 const Subject = styled.div`
 	display: inline-block;

--- a/src/components/Feed.tsx
+++ b/src/components/Feed.tsx
@@ -23,11 +23,11 @@ export default function Feed({ posts }: { posts: PostType[] }) {
 	const [menuModal, setMenuModal] = useState<ModalState>('closed');
 	const [commentModal, setCommentModal] = useState<ModalState>('closed');
 
-	const [menuPostId, setMenuPostId] = useState<number | null>(null);
+	const [menuPost, setMenuPost] = useState<PostType | null>(null);
 	const [commentPost, setCommentPost] = useState<PostType | null>(null);
 
-	const openMenuModal = (postId: number) => {
-		setMenuPostId(postId);
+	const openMenuModal = (post: PostType) => {
+		setMenuPost(post);
 		setMenuModal('open');
 	};
 
@@ -68,11 +68,11 @@ export default function Feed({ posts }: { posts: PostType[] }) {
 						setMenuModal('closing');
 						setTimeout(() => {
 							setMenuModal('closed');
-							setMenuPostId(null);
+							setMenuPost(null);
 						}, 300);
 					}}
 					isClosing={menuModal === 'closing'}
-					postId={menuPostId}
+					post={menuPost}
 				/>
 			)}
 			{commentModal !== 'closed' && (

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -35,6 +35,7 @@ export default function Post({
 					showMenu={() => {
 						openMenuModal(postData);
 					}}
+					blockInteraction={false}
 				/>
 				<PostImage media={postData.media} />
 				<ReactSection

--- a/src/components/Post/Post.tsx
+++ b/src/components/Post/Post.tsx
@@ -18,7 +18,7 @@ const Container = styled.article`
 
 type Props = {
 	postData: PostType | null;
-	openMenuModal: (postId: number) => void;
+	openMenuModal: (post: PostType) => void;
 	openCommentModal: (post: PostType) => void;
 };
 
@@ -33,7 +33,7 @@ export default function Post({
 				<PostHeader
 					user={postData.user}
 					showMenu={() => {
-						openMenuModal(postData.id);
+						openMenuModal(postData);
 					}}
 				/>
 				<PostImage media={postData.media} />

--- a/src/components/Post/PostHeader.tsx
+++ b/src/components/Post/PostHeader.tsx
@@ -30,15 +30,22 @@ const ExtraButton = styled.button`
 type PostHeaderType = {
 	user: MiniProfileType;
 	showMenu: () => void;
+	blockInteraction: boolean;
 };
 
-export default function PostHeader({ user, showMenu }: PostHeaderType) {
+export default function PostHeader({
+	user,
+	showMenu,
+	blockInteraction = false,
+}: PostHeaderType) {
 	return (
 		<Wrapper>
-			<UserInfo user={user} />
-			<ExtraButton onClick={showMenu}>
-				<Icon src={ellipsis} alt="ellipsis" />
-			</ExtraButton>
+			<UserInfo user={user} blockInteraction={blockInteraction} />
+			{blockInteraction && (
+				<ExtraButton onClick={showMenu}>
+					<Icon src={ellipsis} alt="ellipsis" />
+				</ExtraButton>
+			)}
 		</Wrapper>
 	);
 }

--- a/src/components/Post/PostHeader.tsx
+++ b/src/components/Post/PostHeader.tsx
@@ -41,7 +41,7 @@ export default function PostHeader({
 	return (
 		<Wrapper>
 			<UserInfo user={user} blockInteraction={blockInteraction} />
-			{blockInteraction && (
+			{!blockInteraction && (
 				<ExtraButton onClick={showMenu}>
 					<Icon src={ellipsis} alt="ellipsis" />
 				</ExtraButton>

--- a/src/components/Post/PostList.tsx
+++ b/src/components/Post/PostList.tsx
@@ -33,20 +33,21 @@ export default function PostList({
 
 	return (
 		<Wrapper>
-			{previews?.map((preview) => (
-				<div
-					className="image-wrapper"
-					onClick={() => {
-						if (useHashtag) {
-							navigate(`${callbackUrl}#post${preview.id}`);
-						} else {
-							navigate(`${callbackUrl}/${preview.id}`);
-						}
-					}}
-				>
-					<img src={preview.thumbnailUrl} alt="게시물 이미지" />
-				</div>
-			))}
+			{previews.length > 0 &&
+				previews.map((preview) => (
+					<div
+						className="image-wrapper"
+						onClick={() => {
+							if (useHashtag) {
+								navigate(`${callbackUrl}#post${preview.id}`);
+							} else {
+								navigate(`${callbackUrl}/${preview.id}`);
+							}
+						}}
+					>
+						<img src={preview.thumbnailUrl} alt="게시물 이미지" />
+					</div>
+				))}
 		</Wrapper>
 	);
 }

--- a/src/components/Post/PostMenuModal.tsx
+++ b/src/components/Post/PostMenuModal.tsx
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import saveIcon from '../../assets/Images/Post/save.svg';
@@ -37,7 +38,8 @@ const ButtonGroup = styled.div`
 	gap: 0;
 	font-size: 0;
 	& button {
-		background-color: ${getColor('darkGrey')};
+		background-color: ${getColor('grey')};
+		border: none;
 		min-height: 2rem;
 		font-size: 0.7rem;
 	}
@@ -55,6 +57,8 @@ export default function PostMenuModal({
 	handleDeletePost: (postId: number) => void;
 }) {
 	const { userId } = useUserContext();
+
+	const navigate = useNavigate();
 
 	return (
 		<Modal onBackgroundClick={close} isClosing={isClosing}>
@@ -90,6 +94,15 @@ export default function PostMenuModal({
 					<button>이 게시물이 표시되는 이유</button>
 					<button>숨기기</button>
 					<button>신고</button>
+					{post?.user.userId === userId && (
+						<button
+							onClick={() => {
+								navigate(`/post/edit/${post.id}`);
+							}}
+						>
+							수정
+						</button>
+					)}
 					{post?.user.userId === userId && (
 						<button
 							onClick={() => {

--- a/src/components/Post/PostMenuModal.tsx
+++ b/src/components/Post/PostMenuModal.tsx
@@ -2,9 +2,11 @@ import axios from 'axios';
 import styled from 'styled-components';
 
 import saveIcon from '../../assets/Images/Post/save.svg';
+import { useUserContext } from '../../contexts/UserContext';
 import Icon from '../../shared/Icon';
 import Modal from '../../shared/Modal/Modal';
 import { getColor } from '../../styles/Theme';
+import { PostType } from '../../types';
 
 const ModalContent = styled.div`
 	display: flex;
@@ -42,14 +44,16 @@ const ButtonGroup = styled.div`
 `;
 
 export default function PostMenuModal({
-	postId,
+	post,
 	close,
 	isClosing,
 }: {
-	postId: number | null;
+	post: PostType | null;
 	close: () => void;
 	isClosing: boolean;
 }) {
+	const { userId } = useUserContext();
+
 	return (
 		<Modal onBackgroundClick={close} isClosing={isClosing}>
 			<ModalContent>
@@ -57,7 +61,7 @@ export default function PostMenuModal({
 					<ButtonGroup>
 						<button
 							onClick={async () => {
-								await axios.post(`/api/v1/posts/${postId}/save`);
+								await axios.post(`/api/v1/posts/${post?.id}/save`);
 							}}
 						>
 							<div>
@@ -84,6 +88,7 @@ export default function PostMenuModal({
 					<button>이 게시물이 표시되는 이유</button>
 					<button>숨기기</button>
 					<button>신고</button>
+					{post?.user.userId === userId && <button>삭제</button>}
 				</ButtonGroup>
 			</ModalContent>
 		</Modal>

--- a/src/components/Post/PostMenuModal.tsx
+++ b/src/components/Post/PostMenuModal.tsx
@@ -47,10 +47,12 @@ export default function PostMenuModal({
 	post,
 	close,
 	isClosing,
+	handleDeletePost,
 }: {
 	post: PostType | null;
 	close: () => void;
 	isClosing: boolean;
+	handleDeletePost: (postId: number) => void;
 }) {
 	const { userId } = useUserContext();
 
@@ -88,7 +90,15 @@ export default function PostMenuModal({
 					<button>이 게시물이 표시되는 이유</button>
 					<button>숨기기</button>
 					<button>신고</button>
-					{post?.user.userId === userId && <button>삭제</button>}
+					{post?.user.userId === userId && (
+						<button
+							onClick={() => {
+								handleDeletePost(post.id);
+							}}
+						>
+							삭제
+						</button>
+					)}
 				</ButtonGroup>
 			</ModalContent>
 		</Modal>

--- a/src/components/Post/ReactSection.tsx
+++ b/src/components/Post/ReactSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import { handleLike, handleSave } from '../../apis/post';
@@ -85,6 +86,8 @@ export default function ReactSection({ postData, showComment }: Props) {
 
 	const createdDate = new Date(postData.createdAt);
 
+	const navigate = useNavigate();
+
 	return (
 		postData && (
 			<Container>
@@ -139,7 +142,14 @@ export default function ReactSection({ postData, showComment }: Props) {
 					</span>
 				</TextBox>
 				<TextBox className="margin">
-					<span className="username">{postData.user.username}</span>{' '}
+					<span
+						className="username"
+						onClick={() => {
+							navigate(`/${postData.user.username}`);
+						}}
+					>
+						{postData.user.username}
+					</span>{' '}
 					{postData.content}
 				</TextBox>
 				<TextBox

--- a/src/components/Post/UserInfo.tsx
+++ b/src/components/Post/UserInfo.tsx
@@ -39,16 +39,17 @@ const NameBox = styled.div`
 
 type UserInfoProps = {
 	user: MiniProfileType;
+	blockInteraction: boolean;
 };
 
-export default function UserInfo({ user }: UserInfoProps) {
+export default function UserInfo({ user, blockInteraction }: UserInfoProps) {
 	const navigate = useNavigate();
 	return (
 		<StyledLink>
 			<Container>
 				<ImageBox
 					onClick={() => {
-						navigate(`/${user.username}`);
+						if (!blockInteraction) navigate(`/${user.username}`);
 					}}
 				>
 					<ProfileImage
@@ -62,7 +63,7 @@ export default function UserInfo({ user }: UserInfoProps) {
 				</ImageBox>
 				<NameBox
 					onClick={() => {
-						navigate(`/${user.username}`);
+						if (!blockInteraction) navigate(`/${user.username}`);
 					}}
 				>
 					<span>

--- a/src/components/Post/UserInfo.tsx
+++ b/src/components/Post/UserInfo.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import DefaultProfileIcon from '../../assets/Images/Profile/default-profile.svg';
@@ -21,6 +22,7 @@ const ImageBox = styled.div`
 	overflow: hidden;
 	display: inline;
 	border: 1px solid rgb(214, 214, 214);
+	cursor: pointer;
 `;
 
 const ProfileImage = styled.img`
@@ -32,6 +34,7 @@ const ProfileImage = styled.img`
 const NameBox = styled.div`
 	display: flex;
 	align-items: center;
+	cursor: pointer;
 `;
 
 type UserInfoProps = {
@@ -39,10 +42,15 @@ type UserInfoProps = {
 };
 
 export default function UserInfo({ user }: UserInfoProps) {
+	const navigate = useNavigate();
 	return (
 		<StyledLink>
 			<Container>
-				<ImageBox>
+				<ImageBox
+					onClick={() => {
+						navigate(`/${user.username}`);
+					}}
+				>
 					<ProfileImage
 						src={
 							user.profileImageUrl !== ''
@@ -52,7 +60,11 @@ export default function UserInfo({ user }: UserInfoProps) {
 						alt="profile image"
 					/>
 				</ImageBox>
-				<NameBox>
+				<NameBox
+					onClick={() => {
+						navigate(`/${user.username}`);
+					}}
+				>
 					<span>
 						<b>{user.username}</b>
 					</span>

--- a/src/pages/EditPost/EditPost.tsx
+++ b/src/pages/EditPost/EditPost.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { editPost, getPost } from '../../apis/post';
+import PostHeader from '../../components/Post/PostHeader';
+import PostImage from '../../components/Post/PostImage';
+import { useUserContext } from '../../contexts/UserContext';
+import { getColor } from '../../styles/Theme';
+import { PostType } from '../../types';
+
+const Container = styled.div`
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+`;
+
+const TextAreaWrapper = styled.div`
+	width: 100%;
+	flex: 1 1 0;
+	& > textarea {
+		width: 100%;
+		height: 100%;
+		resize: none;
+		border: none;
+	}
+`;
+
+const HeaderContainer = styled.div`
+	width: 100%;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	border-bottom: 1px solid ${getColor('grey')};
+	margin-bottom: 1rem;
+	padding-bottom: 1rem;
+	& h4 {
+		margin: 0;
+	}
+	& button {
+		margin: 0;
+		border: 0;
+		padding: 0;
+		background: none;
+		font-size: 1rem;
+		cursor: pointer;
+	}
+	& > .title {
+		flex: 1 1 0;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+`;
+
+export default function EditPost() {
+	const [post, setPost] = useState<PostType | null>(null);
+	const [content, setContent] = useState('');
+
+	const { accessToken } = useUserContext();
+
+	const { id } = useParams();
+
+	const navigate = useNavigate();
+
+	useEffect(() => {
+		const fetchPost = async () => {
+			if (id !== undefined && Number.isInteger(Number(id))) {
+				try {
+					const fetchPost = await getPost(Number(id), accessToken);
+					if (!fetchPost) {
+						return;
+					}
+					setPost(fetchPost);
+					setContent(fetchPost.content);
+					return;
+				} catch {
+					return;
+				}
+			}
+		};
+
+		fetchPost();
+	}, []);
+
+	return (
+		post && (
+			<Container>
+				<HeaderContainer>
+					<button
+						onClick={() => {
+							navigate(-1);
+						}}
+					>
+						취소
+					</button>
+					<span className="title">
+						<h4>정보 수정</h4>
+					</span>
+					<button
+						onClick={async () => {
+							const result = await editPost(post.id, content, accessToken);
+							if (result?.status === 'success') navigate(-1);
+						}}
+					>
+						확인
+					</button>
+				</HeaderContainer>
+				<PostHeader
+					user={post.user}
+					showMenu={() => {}}
+					blockInteraction={true}
+				/>
+				<PostImage media={post.media} />
+				<TextAreaWrapper>
+					<textarea
+						value={content}
+						onChange={(e) => {
+							setContent(e.target.value);
+							e.currentTarget.style.height = 'auto';
+							e.currentTarget.style.height =
+								e.currentTarget.scrollHeight + 'px';
+						}}
+						autoFocus
+					></textarea>
+				</TextAreaWrapper>
+			</Container>
+		)
+	);
+}

--- a/src/pages/Explore/DetailExplore.tsx
+++ b/src/pages/Explore/DetailExplore.tsx
@@ -120,7 +120,7 @@ export default function DetailExplore() {
 
 	return (
 		<>
-			<BackHeader backURL="-1" title="탐색탭" />
+			<BackHeader backURL="/explore" title="탐색탭" />
 			<PostList
 				previews={previewData.previews}
 				callbackUrl={'/explore/' + category}

--- a/src/pages/Explore/DetailExplore.tsx
+++ b/src/pages/Explore/DetailExplore.tsx
@@ -1,0 +1,132 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { CategoryMap, getCategoryExplore } from '../../apis/explore';
+import Header from '../../components/Post/Header';
+import PostList from '../../components/Post/PostList';
+import { useUserContext } from '../../contexts/UserContext';
+import { ExplorePreviewType } from '../../types';
+
+type FeedFetchStatus = 'pending' | 'complete' | 'fail';
+
+type OptionType = {
+	onScrollEnd?: () => void;
+};
+
+type ReturnType = {
+	isEnd: boolean;
+};
+
+export default function DetailExplore() {
+	const { category } = useParams();
+
+	const [previewData, setPreviewData] = useState<ExplorePreviewType>({
+		previews: [],
+		pageInfo: {
+			hasNext: true,
+			page: 0,
+			size: 0,
+			offset: 0,
+			elements: 0,
+		},
+	});
+
+	const [status, setStatus] = useState<FeedFetchStatus>('pending');
+	const { accessToken } = useUserContext();
+
+	const navigate = useNavigate();
+
+	const lockScroll = useCallback(() => {
+		document.body.style.overflow = 'hidden';
+	}, []);
+
+	const unlockScroll = useCallback(() => {
+		document.body.style.overflow = '';
+	}, []);
+
+	const useInfiniteScroll = ({ onScrollEnd }: OptionType): ReturnType => {
+		const [isEnd, setIsEnd] = useState(false);
+
+		const handleScroll = async () => {
+			const scrollHeight = document.documentElement.scrollHeight;
+			const scrollTop = document.documentElement.scrollTop;
+			const clientHeight = document.documentElement.clientHeight;
+
+			if (scrollTop + clientHeight >= scrollHeight) {
+				setIsEnd(true);
+				lockScroll();
+				if (onScrollEnd) await onScrollEnd();
+				await unlockScroll();
+				await setIsEnd(false);
+			}
+		};
+
+		useEffect(() => {
+			window.addEventListener('scroll', handleScroll);
+			return () => window.removeEventListener('scroll', handleScroll);
+		}, []);
+
+		return { isEnd };
+	};
+
+	useEffect(() => {
+		const fetchHomeFeedData = async () => {
+			if (category && status === 'pending' && previewData.pageInfo.hasNext) {
+				const mappedCategory = CategoryMap[category];
+				if (mappedCategory) {
+					try {
+						const previewFetch = await getCategoryExplore(
+							mappedCategory,
+							previewData.pageInfo.page + 1,
+							accessToken
+						);
+						if (!previewFetch) {
+							setStatus('fail');
+							return;
+						}
+
+						setPreviewData({
+							previews: [...previewData.previews, ...previewFetch.previews],
+							pageInfo: previewFetch.pageInfo,
+						});
+						setStatus('complete');
+					} catch {
+						setStatus('fail');
+					}
+				}
+			} else {
+				setStatus('complete');
+			}
+		};
+
+		fetchHomeFeedData();
+	}, [
+		accessToken,
+		category,
+		navigate,
+		previewData.pageInfo.hasNext,
+		previewData.pageInfo.page,
+		previewData.previews,
+		status,
+	]);
+
+	const { isEnd } = useInfiniteScroll({
+		onScrollEnd: () => {
+			setStatus('pending');
+		},
+	});
+
+	if (category === undefined) return <></>;
+
+	return (
+		<>
+			<Header />
+			<PostList
+				previews={previewData.previews}
+				callbackUrl={'/explore/' + category}
+				useHashtag={false}
+			/>
+			{isEnd && <div>loading</div>}
+		</>
+	);
+}

--- a/src/pages/Explore/DetailExplore.tsx
+++ b/src/pages/Explore/DetailExplore.tsx
@@ -70,7 +70,7 @@ export default function DetailExplore() {
 	};
 
 	useEffect(() => {
-		const fetchHomeFeedData = async () => {
+		const fetchExploreDetailData = async () => {
 			if (category && status === 'pending' && previewData.pageInfo.hasNext) {
 				const mappedCategory = CategoryMap[category];
 				if (mappedCategory) {
@@ -99,7 +99,7 @@ export default function DetailExplore() {
 			}
 		};
 
-		fetchHomeFeedData();
+		fetchExploreDetailData();
 	}, [
 		accessToken,
 		category,

--- a/src/pages/Explore/DetailExplore.tsx
+++ b/src/pages/Explore/DetailExplore.tsx
@@ -2,9 +2,9 @@ import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { CategoryMap, getCategoryExplore } from '../../apis/explore';
-import Header from '../../components/Post/Header';
 import PostList from '../../components/Post/PostList';
 import { useUserContext } from '../../contexts/UserContext';
+import BackHeader from '../../shared/BackHeader';
 import { ExplorePreviewType } from '../../types';
 
 type FeedFetchStatus = 'pending' | 'complete' | 'fail';
@@ -120,7 +120,7 @@ export default function DetailExplore() {
 
 	return (
 		<>
-			<Header />
+			<BackHeader backURL="-1" title="탐색탭" />
 			<PostList
 				previews={previewData.previews}
 				callbackUrl={'/explore/' + category}

--- a/src/pages/Explore/Explore.tsx
+++ b/src/pages/Explore/Explore.tsx
@@ -1,8 +1,9 @@
 // import PostList from '../../components/Post/PostList';
 // import feed from '../../test/data/feed.json';
 import styled from 'styled-components';
-import SubjectBar from '../../components/Explore/SubjectBar';
+
 import Preview from '../../components/Explore/Preview';
+import SubjectBar from '../../components/Explore/SubjectBar';
 
 const Logo = styled.img`
 	width: 8rem;

--- a/src/pages/Explore/ExploreFeed.tsx
+++ b/src/pages/Explore/ExploreFeed.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components';
 
 import { getExploreFeed } from '../../apis/explore';
 import Feed from '../../components/Feed';
-import Header from '../../components/Post/Header';
 import { useUserContext } from '../../contexts/UserContext';
+import BackHeader from '../../shared/BackHeader';
 import { FeedType } from '../../types';
 
 type FeedFetchStatus = 'pending' | 'complete' | 'fail';
@@ -40,7 +40,7 @@ export default function ExploreFeed() {
 		},
 	});
 
-	const { id } = useParams();
+	const { category, id } = useParams();
 
 	const [status, setStatus] = useState<FeedFetchStatus>(`pending`);
 	const { accessToken } = useUserContext();
@@ -132,7 +132,10 @@ export default function ExploreFeed() {
 
 	return (
 		<>
-			<Header />
+			<BackHeader
+				backURL="-1"
+				title={category !== undefined ? category : '뒤로'}
+			/>
 			<Layout>
 				<div className="story-post">
 					<Feed posts={feedData.posts} />

--- a/src/pages/Explore/ExploreFeed.tsx
+++ b/src/pages/Explore/ExploreFeed.tsx
@@ -128,14 +128,16 @@ export default function ExploreFeed() {
 		},
 	});
 
-	if (id === undefined || !Number.isInteger(Number(id))) return <></>;
+	if (
+		category === undefined ||
+		id === undefined ||
+		!Number.isInteger(Number(id))
+	)
+		return <></>;
 
 	return (
 		<>
-			<BackHeader
-				backURL="-1"
-				title={category !== undefined ? category : '뒤로'}
-			/>
+			<BackHeader backURL={'/explore/' + category} title={category} />
 			<Layout>
 				<div className="story-post">
 					<Feed posts={feedData.posts} />

--- a/src/pages/Explore/ExploreFeed.tsx
+++ b/src/pages/Explore/ExploreFeed.tsx
@@ -1,0 +1,3 @@
+export default function ExploreFeed() {
+	return <></>;
+}

--- a/src/pages/Explore/ExploreFeed.tsx
+++ b/src/pages/Explore/ExploreFeed.tsx
@@ -1,3 +1,144 @@
+import { useState, useCallback, useEffect } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { getExploreFeed } from '../../apis/explore';
+import Feed from '../../components/Feed';
+import Header from '../../components/Post/Header';
+import { useUserContext } from '../../contexts/UserContext';
+import { FeedType } from '../../types';
+
+type FeedFetchStatus = 'pending' | 'complete' | 'fail';
+
+type OptionType = {
+	onScrollEnd?: () => void;
+};
+
+type ReturnType = {
+	isEnd: boolean;
+};
+
+const Layout = styled.main`
+	width: 100%;
+	display: flex;
+	flex-direction: row;
+	overflow-y: hidden;
+	margin-top: 1rem;
+	justify-content: center;
+	padding: 0;
+`;
+
 export default function ExploreFeed() {
-	return <></>;
+	const [feedData, setFeedData] = useState<FeedType>({
+		posts: [],
+		pageInfo: {
+			page: 0,
+			size: 0,
+			offset: 0,
+			hasNext: true,
+			elements: 0,
+		},
+	});
+
+	const { id } = useParams();
+
+	const [status, setStatus] = useState<FeedFetchStatus>(`pending`);
+	const { accessToken } = useUserContext();
+
+	const navigate = useNavigate();
+
+	const lockScroll = useCallback(() => {
+		document.body.style.overflow = 'hidden';
+	}, []);
+
+	const unlockScroll = useCallback(() => {
+		document.body.style.overflow = '';
+	}, []);
+
+	const useInfiniteScroll = ({ onScrollEnd }: OptionType): ReturnType => {
+		const [isEnd, setIsEnd] = useState(false);
+
+		const handleScroll = async () => {
+			const scrollHeight = document.documentElement.scrollHeight;
+			const scrollTop = document.documentElement.scrollTop;
+			const clientHeight = document.documentElement.clientHeight;
+
+			if (scrollTop + clientHeight >= scrollHeight) {
+				setIsEnd(true);
+				lockScroll();
+				if (onScrollEnd) await onScrollEnd();
+				await unlockScroll();
+				await setIsEnd(false);
+			}
+		};
+
+		useEffect(() => {
+			window.addEventListener('scroll', handleScroll);
+			return () => window.removeEventListener('scroll', handleScroll);
+		}, []);
+
+		return { isEnd };
+	};
+
+	useEffect(() => {
+		const fetchExploreFeedData = async () => {
+			if (
+				id !== undefined &&
+				status === 'pending' &&
+				feedData.pageInfo.hasNext
+			) {
+				try {
+					const homeFeed = await getExploreFeed(
+						Number(id),
+						feedData.pageInfo.page + 1,
+						accessToken
+					);
+					if (!homeFeed) {
+						setStatus('fail');
+						return;
+					}
+
+					setFeedData({
+						posts: [...feedData.posts, ...homeFeed.posts],
+						pageInfo: homeFeed.pageInfo,
+					});
+					setStatus('complete');
+				} catch {
+					setStatus('fail');
+				}
+			} else {
+				setStatus('complete');
+			}
+		};
+
+		fetchExploreFeedData();
+	}, [
+		accessToken,
+		feedData.pageInfo.hasNext,
+		feedData.pageInfo.page,
+		feedData.posts,
+		id,
+		navigate,
+		status,
+	]);
+
+	const { isEnd } = useInfiniteScroll({
+		onScrollEnd: () => {
+			setStatus('pending');
+		},
+	});
+
+	if (id === undefined || !Number.isInteger(Number(id))) return <></>;
+
+	return (
+		<>
+			<Header />
+			<Layout>
+				<div className="story-post">
+					<Feed posts={feedData.posts} />
+				</div>
+				{isEnd && <div>loading</div>}
+			</Layout>
+		</>
+	);
 }

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -4,8 +4,8 @@ import styled from 'styled-components';
 
 import { tryLogin } from '../../apis/login';
 import { getUserInformation } from '../../apis/user.ts';
-import { useUserContext } from '../../contexts/UserContext';
 import { baseURL } from '../../constants.ts';
+import { useUserContext } from '../../contexts/UserContext';
 
 const Img = styled.img`
 	&.instagram {

--- a/src/pages/Login/signUp/AddPhoto.tsx
+++ b/src/pages/Login/signUp/AddPhoto.tsx
@@ -1,7 +1,7 @@
+import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { useEffect } from 'react';
 import { useUserContext } from '../../../contexts/UserContext';
 
 const Img = styled.img`

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,17 +64,7 @@ export type PostType = {
 	commentCount: number;
 	saved: boolean;
 	hideLike: boolean;
-	category:
-		| 'GAME'
-		| 'TRAVEL'
-		| 'FOOD'
-		| 'SPORT'
-		| 'ANIMAL'
-		| 'LIFE'
-		| 'FASHION'
-		| 'HUMOR'
-		| 'ART'
-		| 'NEWS';
+	category: CategoryType;
 };
 
 export type FeedType = {
@@ -136,4 +126,27 @@ export type MediaType = {
 export type PreviewType = {
 	id: number;
 	thumbnailUrl: string;
+};
+
+export type CategoryType =
+	| 'GAME'
+	| 'TRAVEL'
+	| 'FOOD'
+	| 'SPORT'
+	| 'ANIMAL'
+	| 'LIFE'
+	| 'FASHION'
+	| 'HUMOR'
+	| 'ART'
+	| 'NEWS';
+
+export type ExplorePreviewType = {
+	previews: PreviewType[];
+	pageInfo: {
+		page: number;
+		size: number;
+		offset: number;
+		hasNext: boolean;
+		elements: number;
+	};
 };


### PR DESCRIPTION
### 게시물 관련
- 게시물 삭제 기능 구현
- 게시물 편집 페이지 구현
- 게시물 프로필, 유저 이름 및 댓글창의 프로필 이미지 클릭시 /:user.id로 이동
### 탐색탭 관련
- 더보기 눌렀을 시 페이지 구현
- 이미지 클릭시 피드 페이지 구현

게시물 삭제 및 편집은 테스트 필요